### PR TITLE
Config to send transaction on testnet from fuji to celo

### DIFF
--- a/evm/env/testnet/avax.env
+++ b/evm/env/testnet/avax.env
@@ -48,10 +48,14 @@ export NEW_OWNER_ADDRESS=
 #   Testnet Testing Variables
 #
 ###############################################################################
-export TEST_IS_NATIVE=
-export TEST_TOKEN=
-export TEST_TOKEN_CHAIN=
-export TEST_AMOUNT=
-export TEST_TO_NATIVE_AMOUNT=
-export TEST_TARGET_CHAIN_ID=
-export TEST_SHOULD_WRAP=
+export RELAYER_CONTRACT_ADDRESS=0x99a0b432b9a2bd2be70788825e3232c6f0a17f11
+export RELEASE_BRIDGE_ADDRESS=0x05ca6037eC51F8b712eD2E6Fa72219FEaE74E153
+export RPC=https://api.avax-test.network/ext/bc/C/rpc
+
+export TEST_IS_NATIVE=true
+export TEST_TOKEN=0x1D308089a2D1Ced3f1Ce36B1FcaF815b07217be3
+export TEST_TOKEN_CHAIN=6
+export TEST_AMOUNT=10000000000
+export TEST_TO_NATIVE_AMOUNT=10
+export TEST_TARGET_CHAIN_ID=14
+export TEST_SHOULD_WRAP=false


### PR DESCRIPTION
Get this error when calling

```bash
cd evm
source env/testnet/avax.env
bash shell-scripts/test_transfer.sh
```

```
0) [staticcall]
    │   └─ ← ()
    ├─ [9908] 0x99A0B432b9a2bD2Be70788825E3232C6f0A17f11::calculateRelayerFee(14, 0xd00ae08403B9bbb9124bB305C09058E32C39A48c, 18) [staticcall]
    │   └─ ← 0x00000000000000000000000000000000000000000000000000086108e06510e7
    ├─ [643] 0x99A0B432b9a2bD2Be70788825E3232C6f0A17f11::swapRate(0xd00ae08403B9bbb9124bB305C09058E32C39A48c) [staticcall]
    │   └─ ← 0x000000000000000000000000000000000000000000000000000000007e5ca200
    ├─ [0] console::969cdd03(0000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000007e5ca20000000000000000000000000000000000000000000000000000086108e06510e7000000000000000000000000000000000000000000000000000000000000001c53776170526174653a2025732c2052656c617965724665653a20257300000000) [staticcall]
    │   └─ ← ()
    ├─ [55912] 0x99A0B432b9a2bD2Be70788825E3232C6f0A17f11::wrapAndTransferEthWithRelay{value: 10000000000}(10000000000, 14, 0x00000000000000000000000061a51662f0b30bf176484cac5b4a033c497cb2f3, 0)
  1 config to send transaction on testnet from fuji to celo
    │   ├─ [7222] 0x7bbcE28e64B3F8b84d876Ab298393c38ad7aac4C::messageFee() [staticcall]
    │   │   ├─ [2327] 0x75a4A9AC2687ceF2c441616C006deebC386b99C9::messageFee() [delegatecall]
    │   │   │   └─ ← 0x0000000000000000000000000000000000000000000000000000000000000000
    │   │   └─ ← 0x0000000000000000000000000000000000000000000000000000000000000000
    │   ├─ [23878] 0xd00ae08403B9bbb9124bB305C09058E32C39A48c::deposit{value: 10000000000}()
    │   │   ├─ emit Deposit(param0: 0x99A0B432b9a2bD2Be70788825E3232C6f0A17f11, param1: 10000000000)
    │   │   └─ ← ()
    │   └─ ← "insufficient amount"
    └─ ← "insufficient amount"



== Logs ==
  Transferring Weth to chain: 14
  Amount: 10000000000, toNative: 10000000000
  SwapRate: 2120000000, RelayerFee: 2358490566037735
Error:
insufficient amount
```